### PR TITLE
Add cross-fetch for non-Next applications

### DIFF
--- a/.changeset/strange-parents-watch.md
+++ b/.changeset/strange-parents-watch.md
@@ -1,0 +1,5 @@
+---
+"@cmpsr/contentful-core": patch
+---
+
+Added cross-fetch dependency for non-Next applications

--- a/packages/contentful-core/package.json
+++ b/packages/contentful-core/package.json
@@ -36,6 +36,7 @@
   },
   "dependencies": {
     "apollo-link-http": "^1.5.17",
+    "cross-fetch": "^3.0.5",
     "dotenv": "^8.2.0",
     "invariant": "^2.2.4"
   }

--- a/packages/contentful-core/src/client/createContentfulLink.ts
+++ b/packages/contentful-core/src/client/createContentfulLink.ts
@@ -1,27 +1,40 @@
 import invariant from 'invariant';
+import fetch from 'cross-fetch';
+
 import { createHttpLink } from 'apollo-link-http';
 
-export const createContentfulLink = options => {
+export const createContentfulLink = (options) => {
   const {
     accessToken,
     apiVersion,
     environment,
     space,
     headers,
-  } = Object.assign({}, {
-    environment: 'master',
-    headers: {},
-    apiVersion: 'v1',
-  }, options);
+  } = Object.assign(
+    {},
+    {
+      environment: 'master',
+      headers: {},
+      apiVersion: 'v1',
+    },
+    options
+  );
 
-  invariant(space, 'Contentful `space` ID missing from ContentfulLink initialization.');
-  invariant(accessToken, 'Contentful `accessToken` missing from ContentfulLink initialization');
+  invariant(
+    space,
+    'Contentful `space` ID missing from ContentfulLink initialization.'
+  );
+  invariant(
+    accessToken,
+    'Contentful `accessToken` missing from ContentfulLink initialization'
+  );
 
   return createHttpLink({
     headers: {
       ...headers,
       Authorization: `Bearer ${accessToken}`,
     },
+    fetch,
     uri: `https://graphql.contentful.com/content/${apiVersion}/spaces/${space}/environments/${environment}`, // Server URL (must be absolute)
   });
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -7539,6 +7539,13 @@ cross-fetch@3.0.4:
     node-fetch "2.6.0"
     whatwg-fetch "3.0.0"
 
+cross-fetch@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.5.tgz#2739d2981892e7ab488a7ad03b92df2816e03f4c"
+  integrity sha512-FFLcLtraisj5eteosnX1gf01qYDCOc4fDy0+euOt8Kn9YBY2NtXL/pCoYPavw24NIQkQqm5ZOLsGD5Zzj0gyew==
+  dependencies:
+    node-fetch "2.6.0"
+
 cross-spawn@6.0.5, cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"


### PR DESCRIPTION
## Please delete checklist items and sections that are not relevant

**Checklist**

- [x] Bug fix (non-breaking change which fixes an issue)

**Other information**:

Next.js includes fetch by default, however other stacks do not. Adding `cross-fetch` provides a cross-platform fetch option. 

In a future PR we may want to check for the existence of `fetch` before importing.