### PR TITLE
ComponentMap flexibility

### DIFF
--- a/.changeset/tender-jars-agree.md
+++ b/.changeset/tender-jars-agree.md
@@ -1,0 +1,5 @@
+---
+"@cmpsr/contentful-core": patch
+---
+
+Supplies componentMap to sub components

--- a/packages/contentful-core/src/components/ComponentRenderer/ComponentRenderer.tsx
+++ b/packages/contentful-core/src/components/ComponentRenderer/ComponentRenderer.tsx
@@ -9,35 +9,44 @@ type Props = {
   index?: number;
   parentId?: string;
   rest?: any[];
-}
+};
 
-export const ComponentRenderer = ({ componentMap: componentMapOverrides, data, index, parentId, ...rest }: Props) => {
+export const ComponentRenderer = ({
+  componentMap: componentMapOverrides,
+  data,
+  index,
+  parentId,
+  ...rest
+}: Props) => {
   const contentfulContext = useContext(ContentfulContext);
-  const componentMap = Object.assign({}, contentfulContext.componentMap, componentMapOverrides);
+  const componentMap = Object.assign(
+    {},
+    contentfulContext?.componentMap,
+    componentMapOverrides
+  );
 
   if (Array.isArray(data)) {
-    return data.map((item, index) => renderFromContentfulModel(
-      { componentMap },
-      { ...item, ...rest },
-      index,
-      parentId
-    ));
+    return data.map((item, index) =>
+      renderFromContentfulModel(
+        { componentMap },
+        { ...item, ...rest },
+        index,
+        parentId
+      )
+    );
   }
 
   if (isCollectionShape(data)) {
     const collectionKey = Object.keys(data)[0];
-    return data[collectionKey].items.map((item, index) => renderFromContentfulModel(
-      { componentMap },
-      { ...item, ...rest },
-      index,
-      parentId
-    ));
+    return data[collectionKey].items.map((item, index) =>
+      renderFromContentfulModel(
+        { componentMap },
+        { ...item, ...rest },
+        index,
+        parentId
+      )
+    );
   }
 
-  return renderFromContentfulModel(
-    { componentMap },
-    data,
-    index,
-    parentId
-  );
+  return renderFromContentfulModel({ componentMap }, data, index, parentId);
 };

--- a/packages/contentful-core/src/renderers/renderFromContentfulModel.tsx
+++ b/packages/contentful-core/src/renderers/renderFromContentfulModel.tsx
@@ -11,7 +11,7 @@ export const renderFromContentfulModel = (
   if (!type || !Object.keys(componentMap).includes(type)) return null;
 
   return componentMap[type](
-    { ...item, key: `${parentId}_${item.sys.id}_${index}` },
+    { ...item, key: `${parentId}_${item.sys.id}_${index}`, componentMap },
     index
   );
 };


### PR DESCRIPTION
**Checklist**

- [x] New feature (non-breaking change which adds functionality)

**Other information**:

@ryanhefner - A couple of tiny tweaks here. The first is to allow the context to be null, in situations where we simply want the `ComponentRenderer` without any `Context`. 

The second is to pass `componentMap` to the components themselves, as there are situations where components also want to reference `ComponentRenderer` and lose the overrides at the top level.