### PR TITLE
feat: Add classname to ComponentRenderers

### DIFF
--- a/.changeset/short-bulldogs-dream.md
+++ b/.changeset/short-bulldogs-dream.md
@@ -1,0 +1,5 @@
+---
+"@cmpsr/contentful-core": patch
+---
+
+Adds className to ComponentRenderer components

--- a/packages/contentful-core/src/components/ComponentRenderer/ComponentRenderer.tsx
+++ b/packages/contentful-core/src/components/ComponentRenderer/ComponentRenderer.tsx
@@ -4,6 +4,7 @@ import { renderFromContentfulModel } from 'renderers';
 import { isCollectionShape } from 'utils';
 
 type Props = {
+  className?: string;
   componentMap?: any;
   data?: any;
   index?: number;
@@ -12,6 +13,7 @@ type Props = {
 };
 
 export const ComponentRenderer = ({
+  className = '',
   componentMap: componentMapOverrides,
   data,
   index,
@@ -29,7 +31,7 @@ export const ComponentRenderer = ({
     return data.map((item, index) =>
       renderFromContentfulModel(
         { componentMap },
-        { ...item, ...rest },
+        { ...item, ...rest, className },
         index,
         parentId
       )
@@ -41,7 +43,7 @@ export const ComponentRenderer = ({
     return data[collectionKey].items.map((item, index) =>
       renderFromContentfulModel(
         { componentMap },
-        { ...item, ...rest },
+        { ...item, ...rest, className },
         index,
         parentId
       )
@@ -50,7 +52,7 @@ export const ComponentRenderer = ({
 
   return renderFromContentfulModel(
     { componentMap },
-    { ...data, ...rest },
+    { ...data, ...rest, className },
     index,
     parentId
   );

--- a/packages/contentful-core/src/components/ComponentRendererWithContext/ComponentRendererWithContext.tsx
+++ b/packages/contentful-core/src/components/ComponentRendererWithContext/ComponentRendererWithContext.tsx
@@ -3,6 +3,7 @@ import { ContentfulProvider } from '../../context';
 import { ComponentRendererWithQuery } from '../ComponentRendererWithQuery';
 
 export type ChildProps = {
+  className?: string;
   componentMap: any;
   queryMap: any;
   type: string;
@@ -10,12 +11,17 @@ export type ChildProps = {
 };
 
 export const ComponentRendererWithContext = ({
+  className,
   variables,
   componentMap,
   queryMap,
-  type,
+  type
 }: ChildProps): ReactElement | null => (
   <ContentfulProvider componentMap={componentMap} queryMap={queryMap}>
-    <ComponentRendererWithQuery type={type} variables={variables} />
+    <ComponentRendererWithQuery
+      className={className}
+      type={type}
+      variables={variables}
+    />
   </ContentfulProvider>
 );

--- a/packages/contentful-core/src/components/ComponentRendererWithQuery/ComponentRendererWithQuery.tsx
+++ b/packages/contentful-core/src/components/ComponentRendererWithQuery/ComponentRendererWithQuery.tsx
@@ -4,6 +4,7 @@ import { ContentfulContext } from '../../context';
 import { ComponentRenderer } from '../ComponentRenderer';
 
 export type ChildProps = {
+  className?: string;
   componentMap?: any;
   queryMap?: any;
   type: string;
@@ -11,19 +12,20 @@ export type ChildProps = {
 };
 
 export const ComponentRendererWithQuery = ({
+  className,
   componentMap: componentMapOverride,
   queryMap: queryMapOverride,
   type,
-  variables,
+  variables
 }: ChildProps): ReactElement | null => {
   const {
     componentMap: componentMapDefault,
-    queryMap: queryMapDefault,
+    queryMap: queryMapDefault
   } = useContext(ContentfulContext);
 
   const query = (queryMapOverride || queryMapDefault)[type]();
   const { data } = useQuery(query, {
-    variables,
+    variables
   });
   if (!data) return null;
 
@@ -34,6 +36,7 @@ export const ComponentRendererWithQuery = ({
     key.indexOf('Collection') >= 0 ? data[key].items[0] : data[key];
   return (
     <ComponentRenderer
+      className={className}
       data={dataToParse}
       componentMap={componentMapOverride || componentMapDefault}
     />


### PR DESCRIPTION
## Please delete checklist items and sections that are not relevant

**Checklist**

- [x] Bug fix (non-breaking change which fixes an issue)

**Other information**:

Added `className` as a prop to ComponentRenderer helpers to ensure that `styled-components` and other CSS-in-JS can pass through custom styling down through the tree.