### PR TITLE
Remove postinstall

### DIFF
--- a/.changeset/flat-parrots-relate.md
+++ b/.changeset/flat-parrots-relate.md
@@ -1,0 +1,5 @@
+---
+"@cmpsr/components": patch
+---
+
+remove postinstall script

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -12,7 +12,9 @@
   "license": "MIT",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
-  "files": ["/lib"],
+  "files": [
+    "/lib"
+  ],
   "private": false,
   "scripts": {
     "libbuild": "rimraf lib && babel src --out-dir lib --extensions '.ts,.tsx' --copy-files && tsc -d --declarationDir lib --declarationMap --emitDeclarationOnly && find lib -type f \\( -name '*.test.*' -o -name '*.stories.*' \\) -exec rm {} +",
@@ -22,8 +24,7 @@
     "storybook": "start-storybook -p 8080 -c .storybook",
     "build-storybook": "build-storybook -c .storybook",
     "gen:theme-typings": "./scripts/generate_theme_typings.sh",
-    "gen:icons": "node scripts/generate_icons.js",
-    "postinstall": "npm run gen:theme-typings"
+    "gen:icons": "node scripts/generate_icons.js"
   },
   "peerDependencies": {
     "react": "^17.0.2"

--- a/packages/components/src/theme/ComposerTheme/Components/Select.ts
+++ b/packages/components/src/theme/ComposerTheme/Components/Select.ts
@@ -1,7 +1,10 @@
 import { ComponentStyleConfig } from '@chakra-ui/theme';
-import { PartsStyleObject, SystemStyleInterpolation } from '@chakra-ui/theme-tools';
+import {
+  PartsStyleObject,
+  SystemStyleInterpolation,
+} from '@chakra-ui/theme-tools';
 import { selectAnatomy as parts } from '@chakra-ui/anatomy';
-import { inputStyles } from 'theme/ComposerTheme/styles';
+import { inputStyles } from '../styles';
 
 const iconSpacing = { paddingInlineEnd: '2rem' };
 


### PR DESCRIPTION
The postinstall script was making the package installation to fail, temporary remove it until we found a proper way to do it