### PR TITLE
[COM-393] Add support for leading and trailing icons to Link

### DIFF
--- a/.changeset/afraid-ties-boil.md
+++ b/.changeset/afraid-ties-boil.md
@@ -1,0 +1,5 @@
+---
+"@cmpsr/components": patch
+---
+
+add support for leading and trailing icon to Link component

--- a/packages/components/src/components/primitives/Breadcrumb/types.ts
+++ b/packages/components/src/components/primitives/Breadcrumb/types.ts
@@ -10,6 +10,14 @@ import {
   BreadcrumbSeparatorProps,
 } from '@chakra-ui/react';
 import { FC } from 'react';
+import { IconProps } from '..';
+
+export interface BreadcrumbItem {
+  text: string;
+  link?: string;
+  leftIcon?: FC<IconProps>;
+  rightIcon?: FC<IconProps>;
+}
 
 export interface BreadcrumbStaticMembers {
   Item: FC<BreadcrumbItemProps>;

--- a/packages/components/src/components/primitives/Icons/types.ts
+++ b/packages/components/src/components/primitives/Icons/types.ts
@@ -1,5 +1,5 @@
 export const iconSizes = ['xs', 's', 'm', 'l'] as const;
-type IconSize = typeof iconSizes[number];
+export type IconSize = typeof iconSizes[number];
 
 export interface IconProps {
   color?: string;

--- a/packages/components/src/components/primitives/Link/Link.stories.tsx
+++ b/packages/components/src/components/primitives/Link/Link.stories.tsx
@@ -21,21 +21,11 @@ const AllTemplate = () => {
           <Divider />
 
           <>
-            <Link
-              leftIcon={Icons.IconExternalLink}
-              size={size}
-              role="link"
-              href="#"
-            >
+            <Link leadingIcon={Icons.IconExternalLink} size={size} role="link" href="#">
               Size {size.toUpperCase()} link with left icon
             </Link>
             <Divider />
-            <Link
-              rightIcon={Icons.IconExternalLink}
-              size={size}
-              role="link"
-              href="#"
-            >
+            <Link trailingIcon={Icons.IconExternalLink} size={size} role="link" href="#">
               Size {size.toUpperCase()} link with right icon
             </Link>
             <Divider />
@@ -48,13 +38,13 @@ const AllTemplate = () => {
 
 export const All = AllTemplate.bind({});
 
-const Template = ({ showLeftIcon, showRightIcon, ...args }) => (
+const Template = ({ showLeadingIcon, showTrailingIcon, ...args }) => (
   <VStack>
     <Link
       href="#"
       role="link"
-      {...(showLeftIcon && { leftIcon: Icons.IconExternalLink })}
-      {...(showRightIcon && { rightIcon: Icons.IconExternalLink })}
+      {...(showLeadingIcon && { leadingIcon: Icons.IconExternalLink })}
+      {...(showTrailingIcon && { trailingIcon: Icons.IconExternalLink })}
       {...args}
     >
       Playground
@@ -66,6 +56,6 @@ export const Playground = Template.bind({});
 
 Playground.args = {
   size: 'l',
-  showLeftIcon: true,
-  showRightIcon: true,
+  showLeadingIcon: true,
+  showTrailingIcon: true,
 };

--- a/packages/components/src/components/primitives/Link/Link.stories.tsx
+++ b/packages/components/src/components/primitives/Link/Link.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Meta } from '@storybook/react';
 import { Link } from './Link';
 import { VStack, Divider } from '@chakra-ui/react';
-import { linkSizes, linkIconPositions } from './types';
+import { linkSizes } from './types';
 import * as Icons from '../Icons';
 
 export default {
@@ -19,21 +19,27 @@ const AllTemplate = () => {
             Size {size.toUpperCase()} link
           </Link>
           <Divider />
-          {linkIconPositions.map((position) => (
-            <>
-              <Link
-                iconPosition={position}
-                icon={Icons.IconExternalLink}
-                size={size}
-                key={key}
-                role="link"
-                href="#"
-              >
-                Size {size.toUpperCase()} link with {position} icon
-              </Link>
-              <Divider />
-            </>
-          ))}
+
+          <>
+            <Link
+              leftIcon={Icons.IconExternalLink}
+              size={size}
+              role="link"
+              href="#"
+            >
+              Size {size.toUpperCase()} link with left icon
+            </Link>
+            <Divider />
+            <Link
+              rightIcon={Icons.IconExternalLink}
+              size={size}
+              role="link"
+              href="#"
+            >
+              Size {size.toUpperCase()} link with right icon
+            </Link>
+            <Divider />
+          </>
         </>
       ))}
     </VStack>
@@ -42,12 +48,13 @@ const AllTemplate = () => {
 
 export const All = AllTemplate.bind({});
 
-const Template = ({ showIcon, ...args }) => (
+const Template = ({ showLeftIcon, showRightIcon, ...args }) => (
   <VStack>
     <Link
       href="#"
       role="link"
-      {...(showIcon && { icon: Icons.IconExternalLink })}
+      {...(showLeftIcon && { leftIcon: Icons.IconExternalLink })}
+      {...(showRightIcon && { rightIcon: Icons.IconExternalLink })}
       {...args}
     >
       Playground
@@ -59,6 +66,6 @@ export const Playground = Template.bind({});
 
 Playground.args = {
   size: 'l',
-  iconPosition: 'leading',
-  showIcon: true,
+  showLeftIcon: true,
+  showRightIcon: true,
 };

--- a/packages/components/src/components/primitives/Link/Link.test.tsx
+++ b/packages/components/src/components/primitives/Link/Link.test.tsx
@@ -6,14 +6,13 @@ import { Link } from './Link';
 import { linkSizes } from './types';
 import { IconExternalLink } from '../Icons';
 
-describe('Sizes', () => {
+describe('Link', () => {
   it('should render an anchor', () => {
     renderWithProviders(
       <Link role="link" data-testid="test.id">
         Link
       </Link>
     );
-
     const linkComponent = screen.getByTestId('test.id');
     expect(linkComponent.nodeName).toBe('A');
   });
@@ -27,44 +26,44 @@ describe('Sizes', () => {
     screen.getByText('Link');
   });
 
-  it.each(linkSizes)(
-    `should render the right containers for the size %s`,
-    (size) => {
-      const component = TestRenderer.create(
-        <Link size={size} href="#" role="link">
-          Link
-        </Link>
-      ).root;
+  it.each(linkSizes)(`should render the right containers for the size %s`, (size) => {
+    const component = TestRenderer.create(
+      <Link size={size} href="#" role="link">
+        Link
+      </Link>
+    ).root;
 
-      const linkContainer = component.findByProps({
-        'data-testid': 'cmpsr.link.container',
-      });
-      expect(linkContainer.props.size).toEqual(size);
-    }
-  );
-});
-
-describe('Link and icon components', () => {
-  it('should render', () => {
-    renderWithProviders(<Link data-testid="test.id" />);
-    screen.getByTestId('test.id');
+    const linkContainer = component.findByProps({
+      'data-testid': 'cmpsr.link.container',
+    });
+    expect(linkContainer.props.size).toEqual(size);
   });
 
-  it('should render a link with an icon on the right side', () => {
+  it('should render a link with a trailing icon', () => {
     renderWithProviders(
-      <Link role="link" data-testid="test.id" rightIcon={IconExternalLink}>
+      <Link role="link" trailingIcon={IconExternalLink}>
         Link
       </Link>
     );
-    screen.getByTestId('cmpsr.link.right-icon');
+    screen.getByTestId('cmpsr.link.trailing-icon');
   });
 
-  it('should render a link with an icon on the left side', () => {
+  it('should render a link with a leading icon', () => {
     renderWithProviders(
-      <Link role="link" data-testid="test.id" leftIcon={IconExternalLink}>
+      <Link role="link" leadingIcon={IconExternalLink}>
         Link
       </Link>
     );
-    screen.getByTestId('cmpsr.link.left-icon');
+    screen.getByTestId('cmpsr.link.leading-icon');
+  });
+
+  it('should render a link with leading and trailing icons', () => {
+    renderWithProviders(
+      <Link role="link" leadingIcon={IconExternalLink} trailingIcon={IconExternalLink}>
+        Link
+      </Link>
+    );
+    screen.getByTestId('cmpsr.link.leading-icon');
+    screen.getByTestId('cmpsr.link.trailing-icon');
   });
 });

--- a/packages/components/src/components/primitives/Link/Link.test.tsx
+++ b/packages/components/src/components/primitives/Link/Link.test.tsx
@@ -6,98 +6,65 @@ import { Link } from './Link';
 import { linkSizes } from './types';
 import { IconExternalLink } from '../Icons';
 
-const textElement = <span data-testid="test.id">span component</span>;
-
 describe('Sizes', () => {
-  linkSizes.forEach((size) => {
-    it(`Should render the right containers for the size ${size}`, () => {
+  it('should render an anchor', () => {
+    renderWithProviders(
+      <Link role="link" data-testid="test.id">
+        Link
+      </Link>
+    );
+
+    const linkComponent = screen.getByTestId('test.id');
+    expect(linkComponent.nodeName).toBe('A');
+  });
+
+  it('should render children', () => {
+    renderWithProviders(
+      <Link role="link" data-testid="test.id">
+        Link
+      </Link>
+    );
+    screen.getByText('Link');
+  });
+
+  it.each(linkSizes)(
+    `should render the right containers for the size %s`,
+    (size) => {
       const component = TestRenderer.create(
-        <Link size={size} href="#" icon={IconExternalLink} role="link">
-          {textElement}
+        <Link size={size} href="#" role="link">
+          Link
         </Link>
       ).root;
 
       const linkContainer = component.findByProps({
         'data-testid': 'cmpsr.link.container',
       });
-
       expect(linkContainer.props.size).toEqual(size);
-    });
-  });
+    }
+  );
 });
 
 describe('Link and icon components', () => {
-  it('Should render', () => {
+  it('should render', () => {
     renderWithProviders(<Link data-testid="test.id" />);
     screen.getByTestId('test.id');
   });
 
-  it('Should render a link with an icon on left side as default', () => {
-    const linkComponent = TestRenderer.create(
-      <Link role="link" data-testid="test.id" icon={IconExternalLink}>
-        {textElement}
-      </Link>
-    ).root;
-
-    const flexWrapper = linkComponent.findByProps({
-      'data-testid': 'cmpsr.flex.container',
-    });
-
-    expect(flexWrapper.props.flexDirection).toBe('row');
-  });
-
-  it('Should render a link with an icon on the right side', () => {
-    const linkComponent = TestRenderer.create(
-      <Link
-        role="link"
-        iconPosition="trailing"
-        data-testid="test.id"
-        icon={IconExternalLink}
-      >
-        {textElement}
-      </Link>
-    ).root;
-
-    const flexWrapper = linkComponent.findByProps({
-      'data-testid': 'cmpsr.flex.container',
-    });
-
-    expect(flexWrapper.props.flexDirection).toBe('row');
-  });
-
-  it('Should render a link with an icon on the left side', () => {
-    const linkComponent = TestRenderer.create(
-      <Link
-        role="link"
-        iconPosition="leading"
-        data-testid="test.id"
-        icon={IconExternalLink}
-      >
-        {textElement}
-      </Link>
-    ).root;
-
-    const flexWrapper = linkComponent.findByProps({
-      'data-testid': 'cmpsr.flex.container',
-    });
-
-    expect(flexWrapper.props.flexDirection).toBe('row-reverse');
-  });
-
-  it('Should render a simple link without icon', () => {
+  it('should render a link with an icon on the right side', () => {
     renderWithProviders(
-      <Link role="link" data-testid="test.id">
-        {textElement}
+      <Link role="link" data-testid="test.id" rightIcon={IconExternalLink}>
+        Link
       </Link>
     );
+    screen.getByTestId('cmpsr.link.right-icon');
+  });
 
-    const linkComponent = screen.queryAllByTestId('test.id');
-    const [parentNode, firstChild] = linkComponent;
-
-    expect(linkComponent.length).toBe(2);
-    expect(parentNode.nodeName).toBe('A');
-    expect(firstChild.nodeName).toBe('SPAN');
-    expect(firstChild.nodeName).not.toBe('I');
-    expect(parentNode.nodeName).not.toBe('I');
+  it('should render a link with an icon on the left side', () => {
+    renderWithProviders(
+      <Link role="link" data-testid="test.id" leftIcon={IconExternalLink}>
+        Link
+      </Link>
+    );
+    screen.getByTestId('cmpsr.link.left-icon');
   });
 });

--- a/packages/components/src/components/primitives/Link/Link.tsx
+++ b/packages/components/src/components/primitives/Link/Link.tsx
@@ -1,28 +1,37 @@
 import React, { FC } from 'react';
-import { Link as ChakraLink, Text, Flex } from '@chakra-ui/react';
-
+import { Link as ChakraLink } from '@chakra-ui/react';
 import { LinkProps } from './types';
+import { IconSize, Text } from '..';
+import { Flex } from '../../layouts';
 
 export const Link: FC<LinkProps> = ({
   children,
-  icon: Icon,
-  iconPosition = 'trailing',
+  leftIcon: LeftIcon,
+  rightIcon: RightIcon,
   size = 'm',
   ...props
 }) => (
   <ChakraLink size={size} data-testid="cmpsr.link.container" {...props}>
-    {Icon ? (
-      <Flex
-        gap="spacer-1"
-        alignItems="center"
-        data-testid="cmpsr.flex.container"
-        flexDirection={iconPosition === 'leading' ? 'row-reverse' : 'row'}
+    <Flex direction="row" alignItems="center">
+      {LeftIcon && (
+        <LeftIcon size={getIconSize(size)} data-testid="cmpsr.link.left-icon" />
+      )}
+      <Text
+        {...(LeftIcon && { ml: '0.5rem' })}
+        {...(RightIcon && { mr: '0.5rem' })}
+        isTruncated
       >
-        <Text isTruncated>{children}</Text>
-        <Icon size={size === 'l' ? 'm' : size} />
-      </Flex>
-    ) : (
-      <Text isTruncated>{children}</Text>
-    )}
+        {children}
+      </Text>
+      {RightIcon && (
+        <RightIcon
+          size={getIconSize(size)}
+          data-testid="cmpsr.link.right-icon"
+        />
+      )}
+    </Flex>
   </ChakraLink>
 );
+
+const getIconSize = (size: string): IconSize =>
+  (size === 'l' ? 'm' : size) as IconSize;

--- a/packages/components/src/components/primitives/Link/Link.tsx
+++ b/packages/components/src/components/primitives/Link/Link.tsx
@@ -12,11 +12,9 @@ export const Link: FC<LinkProps> = ({
   ...props
 }) => (
   <ChakraLink size={size} data-testid="cmpsr.link.container" {...props}>
-    <Flex direction="row" alignItems="center">
+    <Flex direction="row" alignItems="center" columnGap="0.5rem">
       {LeadingIcon && <LeadingIcon size={getIconSize(size)} data-testid="cmpsr.link.leading-icon" />}
-      <Text {...(LeadingIcon && { ml: '0.5rem' })} {...(TrailingIcon && { mr: '0.5rem' })} isTruncated>
-        {children}
-      </Text>
+      <Text isTruncated>{children}</Text>
       {TrailingIcon && <TrailingIcon size={getIconSize(size)} data-testid="cmpsr.link.trailing-icon" />}
     </Flex>
   </ChakraLink>

--- a/packages/components/src/components/primitives/Link/Link.tsx
+++ b/packages/components/src/components/primitives/Link/Link.tsx
@@ -6,32 +6,20 @@ import { Flex } from '../../layouts';
 
 export const Link: FC<LinkProps> = ({
   children,
-  leftIcon: LeftIcon,
-  rightIcon: RightIcon,
+  leadingIcon: LeadingIcon,
+  trailingIcon: TrailingIcon,
   size = 'm',
   ...props
 }) => (
   <ChakraLink size={size} data-testid="cmpsr.link.container" {...props}>
     <Flex direction="row" alignItems="center">
-      {LeftIcon && (
-        <LeftIcon size={getIconSize(size)} data-testid="cmpsr.link.left-icon" />
-      )}
-      <Text
-        {...(LeftIcon && { ml: '0.5rem' })}
-        {...(RightIcon && { mr: '0.5rem' })}
-        isTruncated
-      >
+      {LeadingIcon && <LeadingIcon size={getIconSize(size)} data-testid="cmpsr.link.leading-icon" />}
+      <Text {...(LeadingIcon && { ml: '0.5rem' })} {...(TrailingIcon && { mr: '0.5rem' })} isTruncated>
         {children}
       </Text>
-      {RightIcon && (
-        <RightIcon
-          size={getIconSize(size)}
-          data-testid="cmpsr.link.right-icon"
-        />
-      )}
+      {TrailingIcon && <TrailingIcon size={getIconSize(size)} data-testid="cmpsr.link.trailing-icon" />}
     </Flex>
   </ChakraLink>
 );
 
-const getIconSize = (size: string): IconSize =>
-  (size === 'l' ? 'm' : size) as IconSize;
+const getIconSize = (size: string): IconSize => (size === 'l' ? 'm' : size) as IconSize;

--- a/packages/components/src/components/primitives/Link/types.ts
+++ b/packages/components/src/components/primitives/Link/types.ts
@@ -6,7 +6,7 @@ export const linkSizes = ['s', 'm', 'l'] as const;
 type LinkSizes = typeof linkSizes[number];
 
 export interface LinkProps extends ChakraLinkProps {
-  leftIcon?: FC<IconProps>;
   size?: LinkSizes;
-  rightIcon?: FC<IconProps>;
+  leadingIcon?: FC<IconProps>;
+  trailingIcon?: FC<IconProps>;
 }

--- a/packages/components/src/components/primitives/Link/types.ts
+++ b/packages/components/src/components/primitives/Link/types.ts
@@ -2,14 +2,11 @@ import { LinkProps as ChakraLinkProps } from '@chakra-ui/react';
 import { FC } from 'react';
 import { IconProps } from '../Icons';
 
-export const linkIconPositions = ['leading', 'trailing'] as const;
 export const linkSizes = ['s', 'm', 'l'] as const;
-
-type LinkIconPositions = typeof linkIconPositions[number];
 type LinkSizes = typeof linkSizes[number];
 
 export interface LinkProps extends ChakraLinkProps {
-  icon?: FC<IconProps>;
-  iconPosition?: LinkIconPositions;
+  leftIcon?: FC<IconProps>;
   size?: LinkSizes;
+  rightIcon?: FC<IconProps>;
 }


### PR DESCRIPTION
**Checklist**
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Please check if the PR fulfills these requirements**
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Storybook or docs have been added / updated (for bug fixes / features)

**What is the ticket / issue associated with this change?** (Link to the ticket or issue)
- https://impulsumvc.atlassian.net/browse/COM-393
- https://impulsumvc.atlassian.net/browse/COM-379

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
We have replace the `icon` and `iconPosition` props by `leadingIcon` and `trailingIcon`

**Other information**:
- Also fix the spacing between the text and the icons