### PR TITLE
Remove link wrapper

### DIFF
--- a/.changeset/short-dryers-flash.md
+++ b/.changeset/short-dryers-flash.md
@@ -1,0 +1,5 @@
+---
+"@cmpsr/components": minor
+---
+
+feat: remove flex wrapper inside Link

--- a/packages/components/src/components/primitives/Icons/types.ts
+++ b/packages/components/src/components/primitives/Icons/types.ts
@@ -1,8 +1,9 @@
+import { StyleProps } from "@chakra-ui/react";
+
 export const iconSizes = ['xs', 's', 'm', 'l'] as const;
 export type IconSize = typeof iconSizes[number];
 
-export interface IconProps {
-  color?: string;
+export interface IconProps extends StyleProps {
   boxSize?: string;
   size?: IconSize;
 }

--- a/packages/components/src/components/primitives/Link/Link.stories.tsx
+++ b/packages/components/src/components/primitives/Link/Link.stories.tsx
@@ -4,6 +4,7 @@ import { Link } from './Link';
 import { linkSizes, linkVariants } from './types';
 import * as Icons from '../Icons';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@chakra-ui/react';
+import { Text } from '@components';
 
 export default {
   component: Link,
@@ -94,6 +95,16 @@ const AllVariantsTemplate = () => (
 );
 
 export const AllVariants = AllVariantsTemplate.bind({});
+
+export const WrappedByText = () => (
+  <Text>
+    A{' '}
+    <Link _hover={{ textDecoration: 'underline' }} href="#">
+      link
+    </Link>{' '}
+    in the middle of a text with a custom decoration
+  </Text>
+);
 
 const Template = ({ showLeadingIcon, showTrailingIcon, ...args }) => (
   <Link

--- a/packages/components/src/components/primitives/Link/Link.tsx
+++ b/packages/components/src/components/primitives/Link/Link.tsx
@@ -11,11 +11,12 @@ export const Link = forwardRef<LinkProps, typeof ChakraLink>(
       variant={variant}
       data-testid="cmpsr.link.container"
       alignItems="center"
+      columnGap="0.5rem"
       {...props}
     >
-      {LeadingIcon && <LeadingIcon size={getIconSize(size)} data-testid="cmpsr.link.leading-icon" mr="0.5rem" />}
+      {LeadingIcon && <LeadingIcon size={getIconSize(size)} data-testid="cmpsr.link.leading-icon" />}
       {children}
-      {TrailingIcon && <TrailingIcon size={getIconSize(size)} data-testid="cmpsr.link.trailing-icon" ml="0.5rem" />}
+      {TrailingIcon && <TrailingIcon size={getIconSize(size)} data-testid="cmpsr.link.trailing-icon" />}
     </ChakraLink>
   )
 );

--- a/packages/components/src/components/primitives/Link/Link.tsx
+++ b/packages/components/src/components/primitives/Link/Link.tsx
@@ -1,16 +1,21 @@
 import React from 'react';
 import { forwardRef, Link as ChakraLink } from '@chakra-ui/react';
 import { LinkProps } from './types';
-import { Flex, IconSize } from '@components';
+import { IconSize } from '@components';
 
 export const Link = forwardRef<LinkProps, typeof ChakraLink>(
   ({ children, leadingIcon: LeadingIcon, trailingIcon: TrailingIcon, size = 'm', variant, ...props }, ref) => (
-    <ChakraLink ref={ref} size={size} variant={variant} data-testid="cmpsr.link.container" {...props}>
-      <Flex direction="row" alignItems="center" columnGap="0.5rem">
-        {LeadingIcon && <LeadingIcon size={getIconSize(size)} data-testid="cmpsr.link.leading-icon" />}
-        {children}
-        {TrailingIcon && <TrailingIcon size={getIconSize(size)} data-testid="cmpsr.link.trailing-icon" />}
-      </Flex>
+    <ChakraLink
+      ref={ref}
+      size={size}
+      variant={variant}
+      data-testid="cmpsr.link.container"
+      alignItems="center"
+      {...props}
+    >
+      {LeadingIcon && <LeadingIcon size={getIconSize(size)} data-testid="cmpsr.link.leading-icon" mr="0.5rem" />}
+      {children}
+      {TrailingIcon && <TrailingIcon size={getIconSize(size)} data-testid="cmpsr.link.trailing-icon" ml="0.5rem" />}
     </ChakraLink>
   )
 );


### PR DESCRIPTION
This was causing a warning when rendering the Link _wrapped_ by text as `div` should not be a child of `p`
 
**Checklist**
- [X] Bug fix (non-breaking change which fixes an issue)

**Please check if the PR fulfills these requirements**
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Storybook or docs have been added / updated (for bug fixes / features)
