### PR TITLE
Expose create contentful link in contentful-core

### DIFF
--- a/.changeset/spotty-icons-thank.md
+++ b/.changeset/spotty-icons-thank.md
@@ -1,0 +1,5 @@
+---
+"@cmpsr/contentful-core": minor
+---
+
+feat: expose createContentfulLink function

--- a/packages/contentful-core/src/index.ts
+++ b/packages/contentful-core/src/index.ts
@@ -1,0 +1,1 @@
+export { createContentfulLink } from './client';


### PR DESCRIPTION
We need to expose this method to avoid importing it from the full route