### PR TITLE
COM-579: Add globals prop to mdxRenderer component

### DIFF
--- a/packages/nextjs-contentful-renderer/README.md
+++ b/packages/nextjs-contentful-renderer/README.md
@@ -8,7 +8,18 @@ The library exposes the following:
 
 - `getPageContent(context: GetServerSidePropsContext, domain?: string)`. This method takes the nextjs' `context` object and get the page slug to use it to retrieve the content from contentful. To avoid collisions between similar routes in different projects stored in the same contentful space you can pass domain parameter to this function, or you can set the `SITE_DOMAIN` env variable to avoid having to pass it in every single call.
 - `generateMdx(blocks: Block[]): Promise<Model[]>`. This function takes the output of the `getPageContent` and compiles the code to MDX using [mdx-bundler](https://github.com/kentcdodds/mdx-bundler).
-- `MdxRenderer` component. Takes the compiled MDX code from `generateMdx` and renders the content using react. The component accepts the `content` to render and a custom `componentMap` that can be used to render custom components.
+- `MdxRenderer` component. Takes the compiled MDX code from `generateMdx` and renders the content using react. The component accepts the `content` to render, a custom `componentMap` that can be used to render custom components and `mdxGlobals` to set custom variables or you are going to use external libraries, you can read more about it [here](https://github.com/kentcdodds/mdx-bundler#globals)
+
+Example of globals configuration:
+```typescript
+// Your content in mdx format
+<Button trailingIcon={CustomIcon}>Click me</Button>
+
+// Passing your custom variable or component in this case
+<MdxRenderer content={...}  mdxGlobals={{ CustomIcon: () => <p>icon</p> }} />;
+
+```
+If you don't pass `CustomIcon` in the mdxGlobals object, you will get an error like this: `ReferenceError: CustomIcon is not defined`
 
 ## Requirements
 

--- a/packages/nextjs-contentful-renderer/src/MdxRenderer/MdxRenderer.tsx
+++ b/packages/nextjs-contentful-renderer/src/MdxRenderer/MdxRenderer.tsx
@@ -46,7 +46,7 @@ const components: any = Object.keys(Composer).reduce(
   }
 );
 
-export const MdxRenderer: FC<MdxRendererProps> = ({ content = {}, componentMap = {},  mdxGlobals = {}) => {
+export const MdxRenderer: FC<MdxRendererProps> = ({ content = {}, componentMap = {}, mdxGlobals = {} }) => {
   const [isClient, setIsClient] = useState(false);
   const code = Composer.useBreakpointValue(content) || content.base;
   const MdxComponent = useMemo(() => getMDXComponent(code, { ...Icons, ...mdxGlobals }), [code, mdxGlobals]);

--- a/packages/nextjs-contentful-renderer/src/MdxRenderer/MdxRenderer.tsx
+++ b/packages/nextjs-contentful-renderer/src/MdxRenderer/MdxRenderer.tsx
@@ -1,5 +1,6 @@
 import React, { FC, useEffect, useMemo, useState } from 'react';
 import * as Composer from '@cmpsr/components';
+import * as Icons from '@cmpsr/components/lib/components/primitives/Icons';
 import { getMDXComponent } from 'mdx-bundler/client';
 import { Paragraph, Text } from './components';
 import { MdxRendererProps } from './types';
@@ -45,10 +46,10 @@ const components: any = Object.keys(Composer).reduce(
   }
 );
 
-export const MdxRenderer: FC<MdxRendererProps> = ({ content = {}, componentMap = {} }) => {
+export const MdxRenderer: FC<MdxRendererProps> = ({ content = {}, componentMap = {},  mdxGlobals = {}) => {
   const [isClient, setIsClient] = useState(false);
   const code = Composer.useBreakpointValue(content) || content.base;
-  const MdxComponent = useMemo(() => getMDXComponent(code), [code]);
+  const MdxComponent = useMemo(() => getMDXComponent(code, { ...Icons, ...mdxGlobals }), [code, mdxGlobals]);
 
   useEffect(() => {
     setIsClient(true);

--- a/packages/nextjs-contentful-renderer/src/MdxRenderer/types.ts
+++ b/packages/nextjs-contentful-renderer/src/MdxRenderer/types.ts
@@ -4,4 +4,5 @@ import { Model } from '../utils/contentful/getPageById/types';
 export interface MdxRendererProps {
   content: Model;
   componentMap?: ComponentMap;
+  mdxGlobals: Record<string, unknown>;
 }


### PR DESCRIPTION
## Please delete checklist items and sections that are not relevant

**Checklist**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

**Please check if the PR fulfills these requirements**

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Storybook or docs have been added / updated (for bug fixes / features)

**What is the ticket / issue associated with this change?** (Link to the ticket or issue)
https://impulsumvc.atlassian.net/browse/COM-579
**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

**Other information**:
I have created this PR because the Buttons and Links use this format to set icons: `<Link leadingIcon={Icon}` and that causes the error  `Icon is not defined` when rendering mdx content by mdx-bundler, to fix this issue we need to pass a new object to `getMDXComponent` function as a global variables. https://github.com/kentcdodds/mdx-bundler#globals


**Storybook Link** (Link to a local storybook url to review new functionality)
