### PR TITLE
Revert "COM-543: Replace lerna publish command with changeset command"

### DIFF
--- a/.changeset/ten-jokes-dance.md
+++ b/.changeset/ten-jokes-dance.md
@@ -1,0 +1,5 @@
+---
+"@cmpsr/nextjs-contentful-renderer": patch
+---
+
+fix: package release

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:coverage": "turbo run test:coverage",
     "lint": "eslint . --ext .tsx,.ts,.js",
     "lint-and-fix": "eslint . --ext .tsx,.ts,.js --fix",
-    "publish-ci": "turbo run libbuild && turbo run type:emit && changeset publish",
+    "publish-ci": "turbo run libbuild && turbo run type:emit && lerna publish from-package -y --no-verify-access",
     "storybook": "turbo run storybook"
   },
   "private": true,

--- a/packages/nextjs-contentful-renderer/client/package.json
+++ b/packages/nextjs-contentful-renderer/client/package.json
@@ -1,6 +1,5 @@
 {
   "type": "commonjs",
   "main": "./index.js",
-  "types": "./index.d.ts",
-  "private": false
+  "types": "./index.d.ts"
 }


### PR DESCRIPTION
Reverts cmpsr/composer#523

After moving to this the @cmpsr/nextjs-contentful-renderer is no longer being published with the following error

:butterfly:  info Publishing “@cmpsr/nextjs-contentful-renderer” at “14.4.3"
:butterfly:  error an error occurred while publishing @cmpsr/nextjs-contentful-renderer: E402 402 Payment Required - PUT https://registry.npmjs.org/@cmpsr%2fnextjs-contentful-renderer - You must sign up for private packages
:butterfly:  error <Buffer 6e 70 6d 20 6e 6f 74 69 63 65 20 50 75 62 6c 69 73 68 69 6e 67 20 74 6f 20 68 74 74 70 73 3a 2f 2f 72 65 67 69 73 74 72 79 2e 6e 70 6d 6a 73 2e 6f 72 ... 495 more bytes>

Reverting this until we can go deeper in what's going on.