### PR TITLE
[COM-902] Add display flex to HighlightedText Overline

### DIFF
--- a/.changeset/cold-pets-kiss.md
+++ b/.changeset/cold-pets-kiss.md
@@ -1,0 +1,5 @@
+---
+"@cmpsr/blocks": minor
+---
+
+feat: add display flex to HighlightedText Overline

--- a/packages/blocks/src/HighlightedText/HighlightedText.tsx
+++ b/packages/blocks/src/HighlightedText/HighlightedText.tsx
@@ -39,6 +39,6 @@ const HighlightedTextLink: FC<LinkProps> = (props) => (
 HighlightedText.Action = HighlightedTextLink;
 
 const HighlightedTextLegend: FC<TextProps> = (props) => (
-  <Text color="text-secondary" variant="text-body-display-S" textTransform="uppercase" {...props} />
+  <Text color="text-secondary" variant="text-body-display-S" textTransform="uppercase" display="flex" {...props} />
 );
 HighlightedText.Overline = HighlightedTextLegend;


### PR DESCRIPTION
Adding `display:flex` to `HighlightedText.Overline` so we can `alignSelf` the static member

- [x] New feature (non-breaking change which adds functionality)

**Please check if the PR fulfills these requirements**

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Storybook or docs have been added / updated (for bug fixes / features)

**What is the ticket / issue associated with this change?** 
https://impulsumvc.atlassian.net/browse/COM-902
