### PR TITLE
[COM-914] Add support for Overline in BrandLogos block

### DIFF
--- a/.changeset/spicy-paws-rush.md
+++ b/.changeset/spicy-paws-rush.md
@@ -1,0 +1,5 @@
+---
+"@cmpsr/blocks": minor
+---
+
+feat: add support for overline in brandlogos block

--- a/packages/blocks/src/BrandLogos/BrandLogos.stories.tsx
+++ b/packages/blocks/src/BrandLogos/BrandLogos.stories.tsx
@@ -8,6 +8,22 @@ export default {
   title: 'Blocks/BrandLogos',
 } as Meta;
 
+export const WithOverline = () => (
+  <BrandLogos backgroundColor="background-page">
+    <BrandLogos.Overline>BREAKING NEWS</BrandLogos.Overline>
+    <BrandLogos.Title variant="textpairing-header-2XL">
+      <BrandLogos.Title.Label>Title</BrandLogos.Title.Label>
+    </BrandLogos.Title>
+    <BrandLogos.ImagesContainer>
+      {Array(8)
+        .fill('https://avatars0.githubusercontent.com/u/67131017?s=200')
+        .map((image, i) => (
+          <BrandLogos.Image src={image} key={i} maxHeight="12.5rem" />
+        ))}
+    </BrandLogos.ImagesContainer>
+  </BrandLogos>
+);
+
 export const WithText = () => (
   <BrandLogos backgroundColor="background-page">
     <BrandLogos.Title variant="textpairing-header-2XL">

--- a/packages/blocks/src/BrandLogos/BrandLogos.test.tsx
+++ b/packages/blocks/src/BrandLogos/BrandLogos.test.tsx
@@ -43,4 +43,12 @@ describe('BrandLogos', () => {
     );
     screen.getByRole('img');
   });
+  test('should render overline', () => {
+    renderWithProviders(
+      <BrandLogos>
+        <BrandLogos.Overline>Overline</BrandLogos.Overline>
+      </BrandLogos>
+    );
+    screen.getByText('Overline');
+  });
 });

--- a/packages/blocks/src/BrandLogos/BrandLogos.tsx
+++ b/packages/blocks/src/BrandLogos/BrandLogos.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react';
-import { Flex, Image, TextPairing, FlexProps, ImageProps } from '@cmpsr/components';
+import { Flex, Image, Text, TextPairing, FlexProps, ImageProps, TextProps } from '@cmpsr/components';
 
 import { BrandLogosType } from './types';
 
@@ -34,3 +34,8 @@ const BrandLogosImage: FC<ImageProps> = (props) => (
 );
 BrandLogos.Image = BrandLogosImage;
 BrandLogos.Title = TextPairing;
+
+const BrandLogosOverline: FC<TextProps> = (props) => (
+  <Text color="text-secondary" variant="text-body-display-S" textTransform="uppercase" display="flex" {...props} />
+);
+BrandLogos.Overline = BrandLogosOverline;

--- a/packages/blocks/src/BrandLogos/BrandLogos.tsx
+++ b/packages/blocks/src/BrandLogos/BrandLogos.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react';
-import { Flex, Image, Text, TextPairing, FlexProps, ImageProps, TextProps } from '@cmpsr/components';
+import { Flex, Image, Text, TextPairing, FlexProps, ImageProps, TextProps, TextPairingType } from '@cmpsr/components';
 
 import { BrandLogosType } from './types';
 
@@ -11,7 +11,6 @@ export const BrandLogos: BrandLogosType = (props) => (
     alignItems="center"
     py={{ base: '3.5rem', md: '4rem', lg: '5.5rem', xl: '7rem' }}
     px="2rem"
-    gap={{ base: '2rem', md: '2.75rem', lg: '4.75rem' }}
     {...props}
   />
 );
@@ -33,9 +32,22 @@ const BrandLogosImage: FC<ImageProps> = (props) => (
   <Image maxWidth={{ base: '10rem', md: '11.25rem', xl: '12.5rem' }} {...props} />
 );
 BrandLogos.Image = BrandLogosImage;
-BrandLogos.Title = TextPairing;
+
+const BrandLogosTextPairing: TextPairingType = (props) => (
+  <TextPairing marginBottom={{ base: '2rem', md: '2.75rem', lg: '4.75rem' }} {...props} />
+);
+BrandLogosTextPairing.Label = TextPairing.Label;
+BrandLogosTextPairing.SubLabel = TextPairing.SubLabel;
+BrandLogos.Title = BrandLogosTextPairing;
 
 const BrandLogosOverline: FC<TextProps> = (props) => (
-  <Text color="text-secondary" variant="text-body-display-S" textTransform="uppercase" display="flex" {...props} />
+  <Text
+    color="text-secondary"
+    variant="text-body-display-S"
+    textTransform="uppercase"
+    display="flex"
+    marginBottom="1rem"
+    {...props}
+  />
 );
 BrandLogos.Overline = BrandLogosOverline;

--- a/packages/blocks/src/BrandLogos/types.ts
+++ b/packages/blocks/src/BrandLogos/types.ts
@@ -1,11 +1,12 @@
 import { FC } from 'react';
-import { FlexProps, Image, Flex, TextPairing } from '@cmpsr/components';
+import { FlexProps, Image, Flex, TextPairing, Text } from '@cmpsr/components';
 export { FlexProps as BrandLogosProps } from '@cmpsr/components';
 
 export interface BrandLogosStaticMembers {
   Image: typeof Image;
   ImagesContainer: typeof Flex;
   Title: typeof TextPairing;
+  Overline: typeof Text;
 }
 
 export type BrandLogosType = FC<FlexProps> & BrandLogosStaticMembers;


### PR DESCRIPTION
**Description**

- Add support for `Overline` in `BrandLogos` block
- Replace `BrandLogos gap` for `marginBottom` to match design

**Checklist**

- [x] New feature (non-breaking change which adds functionality)

**Please check if the PR fulfills these requirements**

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Storybook or docs have been added / updated (for bug fixes / features)

**What is the ticket / issue associated with this change?**
https://impulsumvc.atlassian.net/browse/COM-914
