### PR TITLE
fix: remove invalid storybook title with double slash

### DIFF
--- a/packages/components/src/components/other/Card/Card.stories.tsx
+++ b/packages/components/src/components/other/Card/Card.stories.tsx
@@ -6,7 +6,7 @@ import { Box, Text } from '@components';
 
 export default {
   component: Card,
-  title: 'Components/Other//Card',
+  title: 'Components/Other/Card',
 } as Meta;
 
 const Template = (args: CardProps) => (


### PR DESCRIPTION
**Checklist**

- [x] Bug fix (non-breaking change which fixes an issue)

**Other information**:

Storybook is broken due to an invalid sb title
