### PR TITLE
COM-1167 Adds permissions to delete storybook github action

### DIFF
--- a/.github/workflows/delete_storybook.yml
+++ b/.github/workflows/delete_storybook.yml
@@ -7,6 +7,10 @@ env:
 
 jobs:
   delete:
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
     if: ${{github.event.ref_type == 'branch' && github.event.ref != 'changeset-release/master'}}
     name: Delete storybook
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Please delete checklist items and sections that are not relevant

**Checklist**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Please check if the PR fulfills these requirements**

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Storybook or docs have been added / updated (for bug fixes / features)

**Other information**:

Looks like it missing permissions to be able to authenticate with google cloud

<img width="1387" alt="image" src="https://user-images.githubusercontent.com/11096470/218760453-c98171c4-96c1-4ab1-8db4-ad8dcde109c5.png">
