### PR TITLE
Add missing `CONTENTFUL_ENVIRONMENT` default

### DIFF
--- a/.changeset/brown-pants-pull.md
+++ b/.changeset/brown-pants-pull.md
@@ -1,0 +1,5 @@
+---
+"@cmpsr/nextjs-contentful-renderer": patch
+---
+
+Add missing `CONTENTFUL_ENVIRONMENT` default

--- a/packages/nextjs-contentful-renderer/src/utils/getApolloClient/getApolloClient.ts
+++ b/packages/nextjs-contentful-renderer/src/utils/getApolloClient/getApolloClient.ts
@@ -6,7 +6,7 @@ export const getApolloClient = ({
   space = process.env.CONTENTFUL_SPACE_ID,
   deliveryAccessToken = process.env.CONTENTFUL_ACCESS_TOKEN_DELIVERY,
   previewAccessToken = process.env.CONTENTFUL_ACCESS_TOKEN_PREVIEW,
-  environment = process.env.CONTENTFUL_ENVIRONMENT,
+  environment = process.env.CONTENTFUL_ENVIRONMENT || 'master',
 } = {}) =>
   new ApolloClient({
     link: createContentfulLink({


### PR DESCRIPTION
## Please delete checklist items and sections that are not relevant

**Checklist**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Please check if the PR fulfills these requirements**

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Storybook or docs have been added / updated (for bug fixes / features)

**What is the ticket / issue associated with this change?** (Link to the ticket or issue)

Resolves an issue if the `CONTENTFUL_ENVIRONMENT` is not set in the `.env` it will properly default to `master`.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

**Other information**:

**Storybook Link** (Link to a local storybook url to review new functionality)
