### PR TITLE
Refactor Boolean and Number Field Types to Default to Undefined

### DIFF
--- a/.changeset/stupid-dingos-rescue.md
+++ b/.changeset/stupid-dingos-rescue.md
@@ -1,0 +1,5 @@
+---
+"@cmpsr/cml": minor
+---
+
+feat: refactor number and boolean field types to default to undefined

--- a/packages/cml/src/replaceCmlPlaceholders/replaceCmlPlaceholders.test.ts
+++ b/packages/cml/src/replaceCmlPlaceholders/replaceCmlPlaceholders.test.ts
@@ -25,6 +25,12 @@ describe('replaceCmlPlaceholders', () => {
     const mdx = replaceCmlPlaceholders(model, values);
     expect(mdx).toStrictEqual({ base: '<Text prop={false}/>' });
   });
+  test('should replace boolean props with value as undefined', () => {
+    const model = { base: '<Text prop={{prop:boolean}}/>' };
+    const values = { base: { prop: undefined } };
+    const mdx = replaceCmlPlaceholders(model, values);
+    expect(mdx).toStrictEqual({ base: '<Text prop={undefined}/>' });
+  });
   test('should replace boolean props with default value as boolean', () => {
     const model = { base: '<Text prop={{prop:boolean:false}}/>' };
     const mdx = replaceCmlPlaceholders(model, {});
@@ -41,6 +47,12 @@ describe('replaceCmlPlaceholders', () => {
     const values = { base: { prop: 5 } };
     const mdx = replaceCmlPlaceholders(model, values);
     expect(mdx).toStrictEqual({ base: '<Text prop={5}/>' });
+  });
+  test('should replace number props with value as undefined', () => {
+    const model = { base: '<Text prop={{prop:number}}/>' };
+    const values = { base: { prop: undefined } };
+    const mdx = replaceCmlPlaceholders(model, values);
+    expect(mdx).toStrictEqual({ base: '<Text prop={undefined}/>' });
   });
   test.each`
     description    | prop

--- a/packages/cml/src/replaceCmlPlaceholders/replaceCmlPlaceholders.ts
+++ b/packages/cml/src/replaceCmlPlaceholders/replaceCmlPlaceholders.ts
@@ -77,7 +77,11 @@ const replacePropValues = (mdx: string, values: Record<string, string> = {}): st
       case 'boolean':
       case 'number':
         searchValue = match;
-        newValue = `{${propValue ?? defaultValue}}`;
+        if (propValue === undefined && (defaultValue === undefined || defaultValue === '')) {
+          newValue = '{undefined}';
+        } else {
+          newValue = `{${propValue ?? defaultValue}}`;
+        }
         break;
       case 'json':
         searchValue = match;

--- a/packages/cml/src/types.ts
+++ b/packages/cml/src/types.ts
@@ -13,6 +13,7 @@ export type PropsValue = ResponsiveValue<
     | boolean
     | Array<string>
     | Record<string, string | string[] | number | boolean | number[] | boolean[]>
+    | undefined
   >
 >;
 


### PR DESCRIPTION
**Description**

This PR enhances the handling of boolean and number field types by updating them to default to undefined when both the value and defaultValue are undefined.

**Checklist**

- [x] New feature (non-breaking change which adds functionality)

**Please check if the PR fulfills these requirements**

- [x] Tests for the changes have been added (for bug fixes / features)
