### PR TITLE
[COM-1442] Add new isInline property to Link component

### DIFF
--- a/.changeset/silly-peas-wink.md
+++ b/.changeset/silly-peas-wink.md
@@ -1,0 +1,5 @@
+---
+"@cmpsr/components": patch
+---
+
+feat: add isInline property to Link component to integrate seamlessly with surrounding texts

--- a/packages/components/src/components/navigation/Link/Link.stories.tsx
+++ b/packages/components/src/components/navigation/Link/Link.stories.tsx
@@ -67,14 +67,14 @@ export const WrappedByText = () => (
       <code>isInline</code> is set, the link is displayed inline, allowing the text to wrap naturally in confined
       spaces. Notice how the long link text:{' '}
       <Link _hover={{ textDecoration: 'underline' }} href="#" isInline>
-        "This is a very long link text that demonstrates effective wrapping within a narrow container"
+        &quot;This is a very long link text that demonstrates effective wrapping within a narrow container&quot;
       </Link>{' '}
       integrates seamlessly with surrounding text, wrapping to the next line as needed.
     </Text>
     <Text mt="4">
-      Here's another link with a trailing icon and extended content, demonstrating the inline wrapping behavior:{' '}
+      Here&apos;s another link with a trailing icon and extended content, demonstrating the inline wrapping behavior:{' '}
       <Link _hover={{ textDecoration: 'underline' }} href="#" isInline trailingIcon={<IconExternalLink />}>
-        "Long link text with an icon, showing how it wraps in a confined space"
+        &quot;Long link text with an icon, showing how it wraps in a confined space&quot;
       </Link>{' '}
       in the text flow.
     </Text>

--- a/packages/components/src/components/navigation/Link/Link.stories.tsx
+++ b/packages/components/src/components/navigation/Link/Link.stories.tsx
@@ -2,7 +2,7 @@ import React, { Fragment } from 'react';
 import { Meta } from '@storybook/react';
 import { Link } from './Link';
 import { linkSizes, linkVariants } from './types';
-import { Table, Tbody, Td, Th, Thead, Tr } from '@chakra-ui/react';
+import { Box, Table, Tbody, Td, Th, Thead, Tr } from '@chakra-ui/react';
 import { buttonVariants, IconExternalLink, Text } from '@components';
 
 export default {
@@ -61,13 +61,24 @@ const AllVariantsTemplate = () => (
 export const AllVariants = AllVariantsTemplate.bind({});
 
 export const WrappedByText = () => (
-  <Text>
-    A{' '}
-    <Link _hover={{ textDecoration: 'underline' }} href="#">
-      link
-    </Link>{' '}
-    in the middle of a text with a custom decoration
-  </Text>
+  <Box maxWidth="680px">
+    <Text>
+      This example illustrates the use of the <code>isInline</code> property with the <code>Link</code> component. When{' '}
+      <code>isInline</code> is set, the link is displayed inline, allowing the text to wrap naturally in confined
+      spaces. Notice how the long link text:{' '}
+      <Link _hover={{ textDecoration: 'underline' }} href="#" isInline>
+        "This is a very long link text that demonstrates effective wrapping within a narrow container"
+      </Link>{' '}
+      integrates seamlessly with surrounding text, wrapping to the next line as needed.
+    </Text>
+    <Text mt="4">
+      Here's another link with a trailing icon and extended content, demonstrating the inline wrapping behavior:{' '}
+      <Link _hover={{ textDecoration: 'underline' }} href="#" isInline trailingIcon={<IconExternalLink />}>
+        "Long link text with an icon, showing how it wraps in a confined space"
+      </Link>{' '}
+      in the text flow.
+    </Text>
+  </Box>
 );
 
 const Template = ({ showLeadingIcon, showTrailingIcon, ...args }) => (
@@ -89,4 +100,5 @@ Playground.args = {
   showLeadingIcon: true,
   showTrailingIcon: true,
   variant: undefined,
+  isInline: false,
 };

--- a/packages/components/src/components/navigation/Link/Link.test.tsx
+++ b/packages/components/src/components/navigation/Link/Link.test.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
-import TestRenderer from 'react-test-renderer';
 import { screen, renderWithProviders } from '@tests/renderWithProviders';
 
 import { Link } from './Link';
-import { linkSizes } from './types';
 import { IconExternalLink } from '../../media/Icons';
 
 describe('Link', () => {
@@ -24,19 +22,6 @@ describe('Link', () => {
       </Link>
     );
     screen.getByText('Link');
-  });
-
-  it.each(linkSizes)(`should render the right containers for the size %s`, (size) => {
-    const component = TestRenderer.create(
-      <Link size={size} href="#" role="link">
-        Link
-      </Link>
-    ).root;
-
-    const linkContainer = component.findByProps({
-      'data-testid': 'cmpsr.link.container',
-    });
-    expect(linkContainer.props.size).toEqual(size);
   });
 
   it('should render a link with a trailing icon', () => {
@@ -69,5 +54,15 @@ describe('Link', () => {
     );
     screen.getByTestId('cmpsr.link.leading-icon');
     screen.getByTestId('cmpsr.link.trailing-icon');
+  });
+
+  it('renders with inline style when isInline is true', () => {
+    renderWithProviders(
+      <Link role="link" isInline>
+        Link
+      </Link>
+    );
+    const linkComponent = screen.getByTestId('cmpsr.link.container');
+    expect(linkComponent).toHaveStyle('display: inline');
   });
 });

--- a/packages/components/src/components/navigation/Link/Link.test.tsx
+++ b/packages/components/src/components/navigation/Link/Link.test.tsx
@@ -62,7 +62,7 @@ describe('Link', () => {
         Link
       </Link>
     );
-    const linkComponent = screen.getByTestId('cmpsr.link.container');
+    const linkComponent = screen.getByRole('link');
     expect(linkComponent).toHaveStyle('display: inline');
   });
 });

--- a/packages/components/src/components/navigation/Link/Link.tsx
+++ b/packages/components/src/components/navigation/Link/Link.tsx
@@ -18,7 +18,7 @@ export const Link = forwardRef<LinkProps, typeof ChakraLink>(
     const rightIcon = getIcon(trailingIcon, size, isInline);
 
     return (
-      <ChakraLink ref={ref} data-testid="cmpsr.link.container" {...styles} {...props}>
+      <ChakraLink ref={ref} {...styles} {...props}>
         {leftIcon}
         {children}
         {rightIcon}

--- a/packages/components/src/components/navigation/Link/Link.tsx
+++ b/packages/components/src/components/navigation/Link/Link.tsx
@@ -1,24 +1,24 @@
-import React from 'react';
-import { forwardRef, IconProps, Link as ChakraLink, ResponsiveValue } from '@chakra-ui/react';
+import React, { ReactElement, cloneElement, isValidElement } from 'react';
+import {
+  forwardRef,
+  IconProps,
+  Link as ChakraLink,
+  ResponsiveValue,
+  useStyleConfig,
+  StyleProps,
+  chakra,
+} from '@chakra-ui/react';
 import { LinkProps, LinkSize } from './types';
 import { getIconSize } from './getIconSize';
 
 export const Link = forwardRef<LinkProps, typeof ChakraLink>(
-  ({ children, leadingIcon, trailingIcon, size = 'm', variant, ...props }, ref) => {
-    const leftIcon = getIcon(leadingIcon, size);
-    const rightIcon = getIcon(trailingIcon, size);
+  ({ children, leadingIcon, trailingIcon, size = 'm', variant, isInline = false, ...props }, ref) => {
+    const styles = useStyleConfig('Link', { isInline, variant, size }) as StyleProps;
+    const leftIcon = getIcon(leadingIcon, size, isInline);
+    const rightIcon = getIcon(trailingIcon, size, isInline);
 
     return (
-      <ChakraLink
-        ref={ref}
-        size={size}
-        variant={variant}
-        data-testid="cmpsr.link.container"
-        alignItems="center"
-        columnGap="0.5rem"
-        width="inherit"
-        {...props}
-      >
+      <ChakraLink ref={ref} data-testid="cmpsr.link.container" {...styles} {...props}>
         {leftIcon}
         {children}
         {rightIcon}
@@ -27,10 +27,15 @@ export const Link = forwardRef<LinkProps, typeof ChakraLink>(
   }
 );
 
-const getIcon = (icon: React.ReactElement<IconProps>, size: ResponsiveValue<LinkSize>) => {
-  if (!React.isValidElement(icon)) {
-    return null;
-  }
+const getIcon = (icon: ReactElement<IconProps>, size: ResponsiveValue<LinkSize>, isInline: boolean) => {
+  if (!isValidElement(icon)) return null;
 
-  return React.cloneElement(icon, { size: getIconSize(size) } as Partial<IconProps>);
+  const iconElement = cloneElement(icon, { size: getIconSize(size) } as Partial<IconProps>);
+  return isInline ? (
+    <chakra.span display="inline-flex" verticalAlign="middle" marginInline="0.25rem">
+      {iconElement}
+    </chakra.span>
+  ) : (
+    iconElement
+  );
 };

--- a/packages/components/src/components/navigation/Link/types.ts
+++ b/packages/components/src/components/navigation/Link/types.ts
@@ -14,4 +14,5 @@ export interface LinkProps extends ChakraLinkProps {
   leadingIcon?: ReactElement;
   trailingIcon?: ReactElement;
   variant?: ResponsiveValue<LinkVariant | ButtonVariant>;
+  isInline?: boolean;
 }

--- a/packages/components/src/theme/ComposerTheme/Components/Link.ts
+++ b/packages/components/src/theme/ComposerTheme/Components/Link.ts
@@ -3,7 +3,7 @@ import { StyleFunctionProps } from '@chakra-ui/theme-tools';
 import { linkSizes, buttonVariants } from '@components';
 
 export const linkBaseStyle = {
-  display: 'inline-flex',
+  width: 'inherit',
   borderRadius: '0.25rem',
   _hover: {
     textDecoration: 'none',
@@ -12,7 +12,6 @@ export const linkBaseStyle = {
 
 const generateLink = (colors: { default: string; hover: string; pressed: string; focus: string }) => {
   return {
-    display: 'inline-flex',
     color: colors.default,
     padding: 0,
     borderRadius: '0.25rem',
@@ -82,7 +81,7 @@ const linkPrimary = generateLink({
 });
 
 export const Link: ComponentStyleConfig = {
-  baseStyle: (props) => {
+  baseStyle: (props: StyleFunctionProps & { isInline?: boolean }) => {
     const buttonBaseStyle = {
       ...props.theme.components.Button.baseStyle,
       display: 'inline-flex',
@@ -90,7 +89,18 @@ export const Link: ComponentStyleConfig = {
         textDecorationLine: 'none',
       },
     };
-    return isButtonVariant(props.variant) ? buttonBaseStyle : linkBaseStyle;
+
+    const linkDisplayStyles = {
+      default: { display: 'inline-flex', alignItems: 'center', columnGap: '0.5rem' },
+      inline: { display: 'inline' },
+    }[props.isInline ? 'inline' : 'default'];
+
+    return isButtonVariant(props.variant)
+      ? buttonBaseStyle
+      : {
+          ...linkBaseStyle,
+          ...linkDisplayStyles,
+        };
   },
   sizes: getSizes(),
   variants: {

--- a/packages/components/src/theme/ComposerTheme/Components/Link.ts
+++ b/packages/components/src/theme/ComposerTheme/Components/Link.ts
@@ -81,7 +81,7 @@ const linkPrimary = generateLink({
 });
 
 export const Link: ComponentStyleConfig = {
-  baseStyle: (props: StyleFunctionProps & { isInline?: boolean }) => {
+  baseStyle: (props: StyleFunctionProps & { isInline: boolean }) => {
     const buttonBaseStyle = {
       ...props.theme.components.Button.baseStyle,
       display: 'inline-flex',
@@ -90,10 +90,9 @@ export const Link: ComponentStyleConfig = {
       },
     };
 
-    const linkDisplayStyles = {
-      default: { display: 'inline-flex', alignItems: 'center', columnGap: '0.5rem' },
-      inline: { display: 'inline' },
-    }[props.isInline ? 'inline' : 'default'];
+    const linkDisplayStyles = !props.isInline
+      ? { display: 'inline-flex', alignItems: 'center', columnGap: '0.5rem' }
+      : { display: 'inline' };
 
     return isButtonVariant(props.variant)
       ? buttonBaseStyle


### PR DESCRIPTION
This pull request introduces the isInline property to the Link component. The addition of this property addresses a specific need for improved text wrapping behavior in scenarios where a link is embedded within a block of text.

**Background:**
Previously, our Link component faced challenges in handling long link texts within confined spaces, especially when the link was part of a larger text block. The standard inline-flex display didn't provide the flexibility needed for text wrapping, resulting in layout issues.

<img width="500" alt="Screenshot 2023-11-17 at 12 40 36" src="https://github.com/cmpsr/composer/assets/20446871/a98caac1-adc8-45a3-adf9-d56f75a89baa">

**Checklist**

- [x] New feature (non-breaking change which adds functionality)

**Please check if the PR fulfills these requirements**

- [x] Storybook or docs have been added / updated (for bug fixes / features)

**What is the ticket / issue associated with this change?**
https://impulsumvc.atlassian.net/browse/COM-1442

<img width="523" alt="Screenshot 2023-11-17 at 12 37 24" src="https://github.com/cmpsr/composer/assets/20446871/3506fa4a-dcab-4156-bbea-84343b1d3077">

